### PR TITLE
Validate AWS credentials are not empty

### DIFF
--- a/src/getMSKAuthToken.spec.ts
+++ b/src/getMSKAuthToken.spec.ts
@@ -59,6 +59,28 @@ describe("generateAuthTokenFromCredentialsProvider", () => {
             awsCredentialsProvider: undefined
         })).rejects.toThrowError("AWS credentials provider cannot be empty to generate auth token.")
     });
+
+    it("should throw error when accessKeyId is empty",  () => {
+        expect(generateAuthTokenFromCredentialsProvider({
+            region: "us-east-1",
+            awsCredentialsProvider: jest.fn().mockReturnValue(Promise.resolve({
+                accessKeyId: '',
+                secretAccessKey: 'testSecretAccessKey',
+                sessionToken: 'testSessionToken',
+            }))
+        })).rejects.toThrowError("AWS credentials cannot be empty to generate auth token.")
+    });
+
+    it("should throw error when secretAccessKey is empty",  () => {
+        expect(generateAuthTokenFromCredentialsProvider({
+            region: "us-east-1",
+            awsCredentialsProvider: jest.fn().mockReturnValue(Promise.resolve({
+                accessKeyId: 'testAccessKeyId',
+                secretAccessKey: '',
+                sessionToken: 'testSessionToken',
+            }))
+        })).rejects.toThrowError("AWS credentials cannot be empty to generate auth token.")
+    });
 });
 
 describe("generateAuthToken", () => {

--- a/src/getMSKAuthToken.ts
+++ b/src/getMSKAuthToken.ts
@@ -94,13 +94,18 @@ export const generateAuthTokenFromCredentialsProvider = async (options: Generate
     if (!options.awsCredentialsProvider) {
         throw new Error("AWS credentials provider cannot be empty to generate auth token.");
     }
+    // Fetch credentials
+    const credentials = await options.awsCredentialsProvider();
+    if (!credentials.accessKeyId || !credentials.secretAccessKey) {
+        throw new Error("AWS credentials cannot be empty to generate auth token.");
+    }
     const hostname = getHostName(options.region);
 
     // Create SigV4 signer with credentials
     const signer = new SignatureV4({
         service: SIGNING_SERVICE,
         region: options.region,
-        credentials: options.awsCredentialsProvider,
+        credentials: credentials,
         sha256: Sha256,
         applyChecksum: false
     });


### PR DESCRIPTION
### Description
Validate AWS credentials are not empty

### Testing
* Verified: ` npm ci && npm run build && npm run test`
* Test coverage:

```
> jest --coverage

 PASS  src/getMSKAuthToken.spec.ts
  generateAuthTokenFromCredentialsProvider
    ✓ should generate auth token with provided credentials (7 ms)
    ✓ should throw error when region is empty (7 ms)
    ✓ should throw error when credentials provider is null/undefined
    ✓ should throw error when accessKeyId is empty (1 ms)
    ✓ should throw error when secretAccessKey is empty
  generateAuthToken
    ✓ should generate auth token with default credentials (2 ms)
    ✓ should throw error when region is empty (1 ms)
  generateAuthTokenFromProfile
    ✓ should generate auth token with profile name input (1 ms)
    ✓ should throw error when profile name is empty (1 ms)
  generateAuthTokenFromRole
    ✓ should generate auth token with role arn input (1 ms)
    ✓ should generate auth token with role arn and session name input (1 ms)
    ✓ should throw error when role arn is empty

--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------|---------|----------|---------|---------|-------------------
All files                 |     100 |      100 |     100 |     100 |                   
 constants.ts             |     100 |      100 |     100 |     100 |                   
 getMSKAuthToken.ts       |     100 |      100 |     100 |     100 |                   
 mskCredentialProvider.ts |     100 |      100 |     100 |     100 |                   
 version.ts               |     100 |      100 |     100 |     100 |                   
--------------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        1.002 s
Ran all test suites.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.