### PR TITLE
GenerateAuthTokenResponse - Clarify expiryTime comment to indicate epoch timestamp

### DIFF
--- a/src/getMSKAuthToken.ts
+++ b/src/getMSKAuthToken.ts
@@ -25,7 +25,7 @@ export interface GenerateAuthTokenResponse {
     token: string;
 
     /**
-     * Token expiry time in millis.
+     * Token expiration time in milliseconds since Unix epoch.
      */
     expiryTime: number;
 }


### PR DESCRIPTION
### Issue
No issue

### Description
I found the description of `expiryTime` somewhat confusing.
I understood this as a "duration" (i.e. diff between two timestamps) and not an absolute time since 1970.
I've suggested a slightly different description.
Happy to hear what you think
