### PR TITLE
Account for partial seconds in credential expiration

### DIFF
--- a/src/getMSKAuthToken.spec.ts
+++ b/src/getMSKAuthToken.spec.ts
@@ -78,12 +78,13 @@ describe("generateAuthTokenFromCredentialsProvider", () => {
     it("should generate auth token with expiryTime sooner when credential close to expiring", async () => {
         const now = Date.now();
         jest.useFakeTimers().setSystemTime(now);
-        const ttl = 10;
+        const ttlMs = 9900; // account for an expiration time of partial seconds
+        const ttlS = 9;
         const credentials = {
             accessKeyId: 'testAccessKeyId',
             secretAccessKey: 'testSecretAccessKey',
             sessionToken: 'testSessionToken',
-            expiration: new Date(now + ttl * 1000),
+            expiration: new Date(now + ttlMs),
         };
         const expiringMockCredentialProvider = jest.fn().mockReturnValue(Promise.resolve(credentials));
         const authTokenResponse = await generateAuthTokenFromCredentialsProvider({
@@ -95,7 +96,7 @@ describe("generateAuthTokenFromCredentialsProvider", () => {
         verifyAuthTokenResponse(authTokenResponse);
         expect(mockNodeProviderChain).toBeCalledTimes(0);
         const signedUrl = getURLFromAuthToken(authTokenResponse.token);
-        verifySignedURL(signedUrl, "us-east-1", ttl);
+        verifySignedURL(signedUrl, "us-east-1", ttlS);
         verifyCallerIdentityInvokes("us-east-1", credentials);
     });
 

--- a/src/getMSKAuthToken.ts
+++ b/src/getMSKAuthToken.ts
@@ -155,7 +155,7 @@ export const generateAuthTokenFromCredentialsProvider = async (options: Generate
     };
 
     const ttl = credentials.expiration !== undefined
-        ? Math.min((credentials.expiration.getTime() - Date.now()) / 1000, EXPIRY_IN_SECONDS)
+        ? Math.min(Math.floor((credentials.expiration.getTime() - Date.now()) / 1000), EXPIRY_IN_SECONDS)
         : EXPIRY_IN_SECONDS;
 
     // Sign request


### PR DESCRIPTION
### Description
When a token is generated with credentials from a credentials provider and the expiration time for these credentials are lower than 900, usually this results in a non-integer value (e.g. 899.456), which means the resulting X-Amz-Expires header becomes a non-integer, which is invalid. This PR solves this by rounding the expiration time down.

### Testing
Modified existing unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.